### PR TITLE
Fix mistakes in TranspilerHelper

### DIFF
--- a/TranspilerHelper.cs
+++ b/TranspilerHelper.cs
@@ -29,7 +29,7 @@ public static class TranspilerHelper
         {
             operand = AccessTools.Field(code.CallerType, code.OperandTarget as string);
         }
-        else if (code.Parameters.Length > 0 || MethodCodes.Contains(code.OpCode))
+        else if (code.Parameters?.Length > 0 || MethodCodes.Contains(code.OpCode))
         {
             operand = AccessTools.Method(code.CallerType, code.OperandTarget as string, code.Parameters);
         }

--- a/TranspilerHelper.cs
+++ b/TranspilerHelper.cs
@@ -29,7 +29,7 @@ public static class TranspilerHelper
         {
             operand = AccessTools.Field(code.CallerType, code.OperandTarget as string);
         }
-        else if (code.Parameters.Length > 0 && MethodCodes.Contains(code.OpCode))
+        else if (code.Parameters.Length > 0 || MethodCodes.Contains(code.OpCode))
         {
             operand = AccessTools.Method(code.CallerType, code.OperandTarget as string, code.Parameters);
         }
@@ -44,7 +44,7 @@ public static class TranspilerHelper
         else
         {
             //OpCode has operand but is of an unsupported type
-            throw new ArgumentException($"Code with OpCode {nameof(code.OpCode)} is not supported.");
+            throw new ArgumentException($"Code with OpCode {code.OpCode} is not supported.");
         }
 
         parsedInstruction.operand = operand;


### PR DESCRIPTION
Fix some mistakes I made in #3 surrounding how instructions are parsed and logged.
The main problem here comes from the "call" instruction check looking for a call OpCode **and** a parameter length > 0 even though calls can have no parameters.