### PR TITLE
Small rework to HarmonyPatchManager and IPaulovHarmonyPatch/NullPaulovHarmonyPatch

### DIFF
--- a/HarmonyPatchManager.cs
+++ b/HarmonyPatchManager.cs
@@ -2,73 +2,63 @@
 using HarmonyLib;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib.Public.Patching;
 
 namespace Paulov.Bepinex.Framework;
 
 public class HarmonyPatchManager
 {
-    private readonly ManualLogSource logger;
+    private readonly ManualLogSource _logger;
     private readonly IPatchProvider _patchProvider;
-    private List<Harmony> harmonyList = [];
+    private readonly Harmony _harmony = new("Paulov.Bepinex.Framework");
 
-    public HarmonyPatchManager(string managerName, IPatchProvider patchProvider = null)
+    public HarmonyPatchManager(string managerName, IPatchProvider patchProvider)
     {
-        logger = Logger.CreateLogSource(managerName ?? GetType().Name);
+        _logger = Logger.CreateLogSource(managerName ?? GetType().Name);
         _patchProvider = patchProvider;
     }
 
-    public void EnablePatches()
+    public int EnableAll()
     {
-        if (_patchProvider == null)
-        {
-            logger.LogError($"{nameof(HarmonyPatchManager)}: No patch provider set. Patches will not be applied.");
-            return;
-        }
+        if (_patchProvider != null) return _patchProvider.GetPatches().Sum(ApplyPatches);
+        
+        _logger.LogError($"{nameof(HarmonyPatchManager)}: No patch provider set. Patches will not be applied.");
+        return 0;
 
-        foreach (IPaulovHarmonyPatch patch in _patchProvider.GetPatches())
+    }
+
+    public int DisableAll()
+    {
+        int patchesRemoved = 0;
+        foreach (MethodBase patch in _harmony.GetPatchedMethods())
         {
             try
             {
-                Type patchType = patch.GetType();
-                Harmony harmony = new Harmony(patchType.Name);
-                if (Activator.CreateInstance(patchType) is not IPaulovHarmonyPatch obj || obj.GetMethodToPatch() == null)
-                    continue;
-
-                _ = harmony.Patch(
-                    obj.GetMethodToPatch(),
-                    obj.GetPrefixMethod(),
-                    obj.GetPostfixMethod(),
-                    obj.GetTranspilerMethod(),
-                    obj.GetFinalizerMethod(),
-                    obj.GetILManipulatorMethod()
-                );
-                harmonyList.Add(harmony);
+                _harmony.Unpatch(patch, HarmonyPatchType.All);
+                patchesRemoved++;
             }
             catch (Exception e)
             {
-                logger.LogError(e);
+                _logger.LogError($"Failed to unpatch {patch.Name}: {e}");
             }
         }
-
-        logger.LogDebug($"{nameof(HarmonyPatchManager)}: {harmonyList.Count} harmony patches applied");
+        
+        return patchesRemoved;
     }
 
-    public void DisablePatches()
+    private int ApplyPatches(IPaulovHarmonyPatch patch)
     {
-        foreach (Harmony harmony in harmonyList)
+        int patchesApplied = 0;
+
+        foreach (MethodBase method in patch.GetMethodsToPatch())
         {
-            try
-            {
-                harmony.UnpatchSelf();
-            }
-            catch (Exception e)
-            {
-                logger.LogError($"Failed to unpatch {harmony.Id}.\n{e}");
-            }
+            _ = _harmony.Patch(method, patch.GetPrefixMethod(), patch.GetPostfixMethod(),
+                patch.GetTranspilerMethod(), patch.GetFinalizerMethod(), patch.GetILManipulatorMethod());
+            patchesApplied++;
         }
-        harmonyList.Clear();
+        
+        return patchesApplied;
     }
-
-
-
 }

--- a/HarmonyPatchManager.cs
+++ b/HarmonyPatchManager.cs
@@ -1,10 +1,8 @@
 ﻿using BepInEx.Logging;
 using HarmonyLib;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using HarmonyLib.Public.Patching;
 
 namespace Paulov.Bepinex.Framework;
 

--- a/IPaulovHarmonyPatch.cs
+++ b/IPaulovHarmonyPatch.cs
@@ -10,7 +10,7 @@ namespace Paulov.Bepinex.Framework
 {
     public interface IPaulovHarmonyPatch
     {
-        MethodBase GetMethodToPatch();
+        IEnumerable<MethodBase> GetMethodsToPatch();
         HarmonyMethod GetPrefixMethod();
         HarmonyMethod GetPostfixMethod();
         HarmonyMethod GetTranspilerMethod();

--- a/IPaulovHarmonyPatch.cs
+++ b/IPaulovHarmonyPatch.cs
@@ -1,10 +1,6 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Paulov.Bepinex.Framework
 {

--- a/Patches/NullPaulovHarmonyPatch.cs
+++ b/Patches/NullPaulovHarmonyPatch.cs
@@ -1,8 +1,6 @@
 ﻿using HarmonyLib;
-using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace Paulov.Bepinex.Framework.Patches
 {

--- a/Patches/NullPaulovHarmonyPatch.cs
+++ b/Patches/NullPaulovHarmonyPatch.cs
@@ -6,36 +6,22 @@ using System.Text;
 
 namespace Paulov.Bepinex.Framework.Patches
 {
-    public class NullPaulovHarmonyPatch : IPaulovHarmonyPatch
+    public abstract class NullPaulovHarmonyPatch : IPaulovHarmonyPatch
     {
-        public virtual HarmonyMethod GetFinalizerMethod()
-        {
-            return null;
-        }
+        public abstract IEnumerable<MethodBase> GetMethodsToPatch();
+        
+        #region GetXMethod
 
-        public virtual HarmonyMethod GetILManipulatorMethod()
-        {
-            return null;
-        }
+        public virtual HarmonyMethod GetFinalizerMethod() => null;
 
-        public virtual MethodBase GetMethodToPatch()
-        {
-            return null;
-        }
+        public virtual HarmonyMethod GetILManipulatorMethod() => null;
 
-        public virtual HarmonyMethod GetPostfixMethod()
-        {
-            return null;
-        }
+        public virtual HarmonyMethod GetPostfixMethod() => null;
 
-        public virtual HarmonyMethod GetPrefixMethod()
-        {
-            return null;
-        }
+        public virtual HarmonyMethod GetPrefixMethod() => null;
 
-        public virtual HarmonyMethod GetTranspilerMethod()
-        {
-            return null;
-        }
+        public virtual HarmonyMethod GetTranspilerMethod() => null;
+
+        #endregion
     }
 }


### PR DESCRIPTION
Slightly reworks the `HarmonyPatchManager` and `IPaulovHarmonyPatch`/`NullPaulovHarmonyPatch` to allow for specifying multiple methods to patch in a single patch (rare, but sometimes useful).

Also cleans up the patching logic a little to make patching and unpatching a little nicer and easier to expand on if desired.

Note: A quick and easy change will need to be made to any dependent assemblies to be compatible