### PR TITLE
Implement helpers for cleaner usage

### DIFF
--- a/HarmonyPatchManager.cs
+++ b/HarmonyPatchManager.cs
@@ -12,10 +12,10 @@ public class HarmonyPatchManager
     private readonly IPatchProvider _patchProvider;
     private readonly Harmony _harmony = new("Paulov.Bepinex.Framework");
 
-    public HarmonyPatchManager(string managerName, IPatchProvider patchProvider)
+    public HarmonyPatchManager(string managerName, IPatchProvider patchProvider = null)
     {
         _logger = Logger.CreateLogSource(managerName ?? GetType().Name);
-        _patchProvider = patchProvider;
+        _patchProvider = patchProvider ?? new ReflectionPatchProvider();
     }
 
     public int EnableAll()

--- a/Patches/NullPaulovHarmonyPatch.cs
+++ b/Patches/NullPaulovHarmonyPatch.cs
@@ -39,9 +39,7 @@ namespace Paulov.Bepinex.Framework.Patches
         {
             if (GetType() == typeof(NullPaulovHarmonyPatch))
                 throw new InvalidOperationException("This method should only be called from a derived type.");
-            Plugin.Logger.LogDebug($"Looking for '{methodName}' in {GetType().Name}");
             MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-            Plugin.Logger.LogDebug($"Found '{method?.Name}' in {GetType().Name}");
             return method == null ? null : new HarmonyMethod(method);
         }
 

--- a/Patches/NullPaulovHarmonyPatch.cs
+++ b/Patches/NullPaulovHarmonyPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -6,20 +7,50 @@ namespace Paulov.Bepinex.Framework.Patches
 {
     public abstract class NullPaulovHarmonyPatch : IPaulovHarmonyPatch
     {
-        public abstract IEnumerable<MethodBase> GetMethodsToPatch();
-        
+        public virtual IEnumerable<MethodBase> GetMethodsToPatch()
+        {
+            MethodBase method = GetMethodToPatch();
+            if (method == null) yield break;
+            yield return method;
+        }
+
+        public virtual MethodBase GetMethodToPatch() => null;
+
         #region GetXMethod
 
-        public virtual HarmonyMethod GetFinalizerMethod() => null;
+        public virtual HarmonyMethod GetFinalizerMethod() =>
+            GetHarmonyMethodFromDerivedClass(HarmonyNameFromMethodName(nameof(GetFinalizerMethod)));
 
-        public virtual HarmonyMethod GetILManipulatorMethod() => null;
+        public virtual HarmonyMethod GetILManipulatorMethod() =>
+            GetHarmonyMethodFromDerivedClass(HarmonyNameFromMethodName(nameof(GetILManipulatorMethod)));
 
-        public virtual HarmonyMethod GetPostfixMethod() => null;
+        public virtual HarmonyMethod GetPostfixMethod() =>
+            GetHarmonyMethodFromDerivedClass(HarmonyNameFromMethodName(nameof(GetPostfixMethod)));
 
-        public virtual HarmonyMethod GetPrefixMethod() => null;
+        public virtual HarmonyMethod GetPrefixMethod() =>
+            GetHarmonyMethodFromDerivedClass(HarmonyNameFromMethodName(nameof(GetPrefixMethod)));
 
-        public virtual HarmonyMethod GetTranspilerMethod() => null;
+        public virtual HarmonyMethod GetTranspilerMethod() =>
+            GetHarmonyMethodFromDerivedClass(HarmonyNameFromMethodName(nameof(GetTranspilerMethod)));
 
         #endregion
+
+        protected HarmonyMethod GetHarmonyMethodFromDerivedClass(string methodName)
+        {
+            if (GetType() == typeof(NullPaulovHarmonyPatch))
+                throw new InvalidOperationException("This method should only be called from a derived type.");
+            Plugin.Logger.LogDebug($"Looking for '{methodName}' in {GetType().Name}");
+            MethodInfo method = GetType().GetMethod(methodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            Plugin.Logger.LogDebug($"Found '{method?.Name}' in {GetType().Name}");
+            return method == null ? null : new HarmonyMethod(method);
+        }
+
+        private string HarmonyNameFromMethodName(string methodName)
+        {
+            const string prefixToTrim = "Get";
+            if (!methodName.StartsWith(prefixToTrim, StringComparison.InvariantCultureIgnoreCase))
+                throw new InvalidOperationException("Method name must start with 'Get'.");
+            return methodName[prefixToTrim.Length..];
+        }
     }
 }

--- a/ReflectionPatchProvider.cs
+++ b/ReflectionPatchProvider.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+
+namespace Paulov.Bepinex.Framework;
+
+public class ReflectionPatchProvider : IPatchProvider
+{
+    public IEnumerable<IPaulovHarmonyPatch> GetPatches()
+    {
+        StackTrace stackTrace = new StackTrace();
+        Assembly thisAssembly = GetType().Assembly;
+        Assembly callingAssembly = null;
+        for (int i = 0; i < stackTrace.FrameCount; i++)
+        {
+            MethodBase stackFrameMethod = stackTrace.GetFrame(i).GetMethod();
+            Assembly stackFrameAssembly = stackFrameMethod?.DeclaringType?.Assembly;
+            if (stackFrameAssembly == thisAssembly) continue;
+            callingAssembly = stackFrameAssembly;
+            break;
+        }
+        
+        if(callingAssembly == null) throw new InvalidOperationException("Could not find calling assembly.");
+        return callingAssembly.GetTypes()
+            .OrderBy(x => x.Name)
+            .Where(x => x.GetInterface(nameof(IPaulovHarmonyPatch)) != null)
+            .Select(x => Activator.CreateInstance(x) as IPaulovHarmonyPatch);
+    }
+}


### PR DESCRIPTION
Implements a new method `GetMethodToPatch` to `NullPaulovHarmonyPatch` and a default implementation to `GetMethodsToPatch` which yields `GetMethodToPatch`. Idea being to make patching single methods cleaner while still allowing multi-method patching.

Also adds default implementation to the `GetXMethod` methods which look for a corresponding static method named `XMethod` in the derived class, removing the need to provide an override for the `GetXMethod` that typically always looked the same as long as you follow conventional naming.

Finally, implements a default `ReflectionPatchProvider` which walks down a stack trace until it finds a method call from outside the framework assembly, then enumerates through the assembly types for anything implementing the `IPaulovHarmonyPatch` interface, assuming they're all intended patches.

The goal of this PR is to reduce the required boilerplate for consumers of the classes while remaining flexible for situations that may need it. There are likely "better" ways to implement some of these changes but they do achieve their goal for now